### PR TITLE
fix: details dialog

### DIFF
--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -256,6 +256,7 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 position: fixed;
                 height: 100%;
                 width: 100%;
+                pointer-events: none;
             }
         </style>
         <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>


### PR DESCRIPTION
![GIFF TITLE](https://media3.giphy.com/media/Tgm9bOjavn9Y5H3MUH/giphy.gif?cid=ecf05e47pdkf9jkp6tzetbwu280yyob4uqcmdhudm2fecwfe&rid=giphy.gif)

## What
On iOS, there was an opened info dialog over the videos.

## Why
With this merge, the dialog won't show up anymore.

## Asana
https://app.asana.com/0/1131903915035003/1199672327950943/f